### PR TITLE
[feat] 现在可合并 manifest，以便在多语言的情况下设置默认语言和启动页等

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -206,12 +206,24 @@ async function handlePrompt(
     gen.generateCode(env);
   }
   if (answers.config) {
+    const answersConfig = HBuilderConfig.hb_cli.HBuilderConfig[answers.config]
     let newHBuilderConfig = merge.deepAssign(
       {},
       HBuilderConfig.hb_cli.HBuilderConfig["base"],
-      HBuilderConfig.hb_cli.HBuilderConfig[answers.config]
+      answersConfig
     );
     HBuilderConfig = merge.deepAssign({}, HBuilderConfig, newHBuilderConfig);
+
+    if (answersConfig && answersConfig.manifest) {
+      // 合并到 manifest ，避免后续的`改版本号`覆盖
+      merge.deepAssign(
+        manifest,
+        HBuilderConfig.hb_cli.HBuilderConfig["base"]?.manifest,
+        answersConfig.manifest
+      )
+      let ManifestConfig = utils.MergeManifestConfig(manifest)
+      await utils.WriteConfig("manifest.json", ManifestConfig)
+    }
   }
 
   if (


### PR DESCRIPTION
允许对 manifest 进行合并，以便区分场景。
例如：
```json
{
  ..........
  "hb_cli": {
    "HBuilderConfig": {
      // 默认情况下使用 uniapp 的通用启动页
      "base": {
        "manifest": {
          "app-plus": {
            "distribute": {
              "splashscreen": {
                "androidStyle": "common"
              }
            }
          }
        }
      },
      "test-zh": {
        "manifest": {
          "name": "打包中文的应用名"
        }
      },
      // 设置为英文应用名、默认语言为英文、设置英文的启动页（比如英文专属的节日活动等）
      "test-en": {
        "android": {
          "packagename": "com.en.app"
        },
        "manifest": {
          "name": "English app name",
          "locale": "en",
          "app-plus": {
            "distribute": {
              "splashscreen": {
                "androidStyle": "default",
                "android": {
                  "xxhdpi": "unpackage/9patch/logo.9.png"
                }
              }
            }
          }
        }
      },
    },
    "env": {
      "base": {},
    }
  }
}

````